### PR TITLE
Remove links to decomissioned MailChimp landing page

### DIFF
--- a/app/views/pages/get_started.html.markerb
+++ b/app/views/pages/get_started.html.markerb
@@ -33,11 +33,7 @@ You’ll be able to get help with this process from the GOV.UK Forms team.
 
 ## Updates and forthcoming features
 
-If GOV.UK Forms doesn’t meet your needs yet, you can:
-
-- [subscribe to our mailing list](<%= mailing_list_path %>)
-to get updates about new features
-- [read about our forthcoming features](<%= forthcoming_features_path %>)
+If GOV.UK Forms doesn’t meet your needs yet, you can [read about our forthcoming features](<%= forthcoming_features_path %>).
 
 ## Contact us
 

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -172,18 +172,9 @@
         </h2>
         <p class="govuk-body">
           GOV.UK Forms is built by a team at the Government Digital
-          Service. You can:
+          Service. <%= govuk_link_to "contact us", support_path %>
+            if you have a question or need help.
         </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>
-            <%= govuk_link_to "contact us", support_path %>
-            if you have a question or need help
-          </li>
-          <li>
-            <%= govuk_link_to "subscribe to our mailing list", mailing_list_path %>
-            to get updates about new features
-          </li>
-        </ul>
       </section>
     </div>
   </div>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -172,7 +172,7 @@
         </h2>
         <p class="govuk-body">
           GOV.UK Forms is built by a team at the Government Digital
-          Service. <%= govuk_link_to "contact us", support_path %>
+          Service. <%= govuk_link_to "Contact us", support_path %>
             if you have a question or need help.
         </p>
       </section>


### PR DESCRIPTION
We've decided to stop using the product site mailing list and decomissioned the relevant landing page in MailChimp - so we should remove the link to the landing page.