### PR TITLE
Remove mailing list redirect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,8 +25,6 @@ Rails.application.routes.draw do
   get "/create-good-forms" => redirect("/about/create-good-forms")
   get "/processing-completed-form-submissions" => redirect("/about/processing-completed-form-submissions")
 
-  get "/mailing-list" => redirect("https://service.us12.list-manage.com/subscribe?u=cb74eb9a6898b0e5870fede0a&id=451fe4c1e1")
-
   resources :performance, only: %i[index]
 
   get "/security.txt" => redirect("https://vulnerability-reporting.service.security.gov.uk/.well-known/security.txt")

--- a/spec/requests/mailing_list_spec.rb
+++ b/spec/requests/mailing_list_spec.rb
@@ -1,9 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "Mailing list", type: :request do
-  it "redirects users to the mailing list subscription page" do
-    get mailing_list_path
-
-    expect(response).to redirect_to %r{https://service.*.list-manage.com/subscribe}
-  end
-end


### PR DESCRIPTION
### What problem does this pull request solve?

Trello card: <!-- link -->

<!-- Add some description here about what the PR is about, even if you have a Trello card to link to -->
We no longer use the product site mailing list, and we've deleted it in Mailchimp. This means that the user will get a Mailchimp 404 page if they follow the URL. We removed all remaining links to the page in #1285.

This commit deletes the redirect, which is no longer needed.

### Things to consider when reviewing

<!-- If this section isn't relevant for your PR feel free to edit or remove it -->

- Does it work when run on your machine?
- Is it clear what the code is doing?
- Do the commit messages explain why the changes were made?
- Are there all the unit tests needed?
- Do the end to end tests need updating before these changes will pass?
- Has all relevant documentation been updated?
